### PR TITLE
Fix curve pool coins interface

### DIFF
--- a/src/integrations/curve/CurvePoolMock.sol
+++ b/src/integrations/curve/CurvePoolMock.sol
@@ -28,8 +28,8 @@ contract CurvePoolMock {
         sendFewTokens = !sendFewTokens;
     }
 
-    function coins() public view returns (address[] memory) {
-        return _coins;
+    function coins(uint256 index) public view returns (address) {
+        return _coins[index];
     }
 
     function redemption_price_snap() public view returns (address) {

--- a/src/interfaces/CurveV1PoolLike.sol
+++ b/src/interfaces/CurveV1PoolLike.sol
@@ -1,7 +1,7 @@
 pragma solidity >=0.6.7;
 
 abstract contract CurveV1PoolLike {
-    function coins() public virtual view returns (address[] memory);
+    function coins(uint256 index) public virtual view returns (address);
     function redemption_price_snap() public virtual view returns (address);
     function lp_token() public virtual view returns (address);
     function remove_liquidity(uint256 _amount, uint256[] memory _min_amounts) public virtual returns (uint256[] memory);

--- a/src/saviours/CurveV1MaxSafeSaviour.sol
+++ b/src/saviours/CurveV1MaxSafeSaviour.sol
@@ -182,12 +182,11 @@ contract CurveV1MaxSafeSaviour is SafeMath, SafeSaviourLike {
         require(address(safeEngine) != address(0), "CurveV1MaxSafeSaviour/null-safe-engine");
         require(address(systemCoin) != address(0), "CurveV1MaxSafeSaviour/null-sys-coin");
 
-        address[] memory coins = curvePool.coins();
-        require(coins.length > 1, "CurveV1MaxSafeSaviour/no-pool-coins");
-
-        for (uint i = 0; i < coins.length; i++) {
+        for (uint i = 0; i < 2; i++) {
+          address coin = curvePool.coins(i);
+          require(coin != address(0), 'CurveV1MaxSafeSaviour/missing-coin');
+          poolTokens.push(coin);
           defaultMinTokensToWithdraw.push(0);
-          poolTokens.push(coins[i]);
         }
 
         emit AddAuthorization(msg.sender);


### PR DESCRIPTION
The curve pool does not exposes a  `coins uint256 => address` mapping but just a simple getter function:
https://etherscan.io/address/0x618788357D0EBd8A37e763ADab3bc575D54c2C7d#code

The number of coins is hardcoded in the curve pool and is always 2. 